### PR TITLE
Change ActionBar title dynamically by the selected tab

### DIFF
--- a/tabs/tabs-page.js
+++ b/tabs/tabs-page.js
@@ -1,8 +1,28 @@
+const TabsViewModel = require("./tabs-view-model");
+
+const viewModel = new TabsViewModel();
+
 function onNavigatingTo(args) { // eslint-disable-line no-unused-vars
     /* ***********************************************************
     * Use the "onNavigatingTo" handler to initialize data for the whole tab
     * navigation layout as a whole.
     *************************************************************/
+
+    const page = args.object;
+
+    page.bindingContext = viewModel;
 }
 
+/* ***********************************************************
+* Get the current tab view title and set it as an ActionBar title.
+* Learn more about the onSelectedIndexChanged event here:
+* https://docs.nativescript.org/cookbook/ui/tab-view#using-selectedindexchanged-event-from-xml
+*************************************************************/
+function onSelectedIndexChanged(args) {
+    const selectedTabViewItem = args.object.items[args.newIndex];
+
+    viewModel.set("title", selectedTabViewItem.title);
+}
+
+exports.onSelectedIndexChanged = onSelectedIndexChanged;
 exports.onNavigatingTo = onNavigatingTo;

--- a/tabs/tabs-page.xml
+++ b/tabs/tabs-page.xml
@@ -5,7 +5,7 @@
   xmlns:featured="/tabs/featured"
   xmlns:settings="/tabs/settings">
     <Page.actionBar>
-        <ActionBar title="Rent a car" icon="" class="action-bar">
+        <ActionBar title="{{ title }}" icon="" class="action-bar">
         </ActionBar>
     </Page.actionBar>
 
@@ -15,7 +15,7 @@
     Learn more about the TabView component in this documentation article:
     http://docs.nativescript.org/cookbook/ui/tab-view
     -->
-    <TabView>
+    <TabView selectedIndexChanged="onSelectedIndexChanged">
       <TabView.items>
         <!--
         To add a new TabView item, simply add a new <TabViewItem> component to the <TabView.items> collection.

--- a/tabs/tabs-view-model.js
+++ b/tabs/tabs-view-model.js
@@ -1,0 +1,11 @@
+const Observable = require("data/observable").Observable;
+
+function TabsViewModel() {
+    const viewModel = new Observable();
+
+    viewModel.title = "";
+
+    return viewModel;
+}
+
+module.exports = TabsViewModel;

--- a/tools/.eslintrc
+++ b/tools/.eslintrc
@@ -17,7 +17,9 @@
         "brace-style": [
             "error",
             "stroustrup",
-            { "allowSingleLine": true }
+            {
+                "allowSingleLine": true
+            }
         ],
         "camelcase": "error",
         "comma-dangle": "error",
@@ -41,7 +43,6 @@
         "id-blacklist": "error",
         "id-match": "error",
         "keyword-spacing": "error",
-        "linebreak-style": "error",
         "max-depth": "error",
         "max-nested-callbacks": "error",
         "max-statements-per-line": "error",


### PR DESCRIPTION
**Current approach:** Apply current TabViewItem `title` property to the tabsPage viewModel `title` property on every tab selection change. I like it because after some thinking I came to the conclusion that every view title should not be in the given view viewModel since it is used only by the main page ActionBar. 

 `<TabViewItem title="Home">` is the one that is will be binded to the ActionBar `title`.  

**[Another approach:](https://www.nativescript.org/blog/guest-post-getting-cozy-with-nativescript's-tabview)** I don't like it, because a lot of code is repeated on every page. (attach and detach tab selection change handlers etc.)

**Failed approach:** Every view viewModel should have `title` property that will be extracted (on every tab selection change event) from the `selectedTabViewItem.bindingContext.title`. Unfortunately, this woudn't work on app start. When `onSelectedIndexChanged` is triggered initially there is still no `.bindingContext` set over the first tab view (Home in our case)